### PR TITLE
Handle RequestType missing

### DIFF
--- a/AWS-Organization-Cost-Categories-automation-installer.yml
+++ b/AWS-Organization-Cost-Categories-automation-installer.yml
@@ -280,13 +280,13 @@ Resources:
           def lambda_handler(event, context):
               """Lambda function handler"""
 
-              if event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
+              if event.get('RequestType') in ('Create', 'Update'):
                   send_response(event, context, "SUCCESS")
 
-              if event['RequestType'] == 'Delete':
+              if event.get('RequestType') == 'Delete':
                   send_response(event, context, "SUCCESS")
                   return
-                  
+
               tags_tree = defaultdict(list)
               cost_categories_arns = {}
               org_accounts = []

--- a/aws_org_costcategories_auto.py
+++ b/aws_org_costcategories_auto.py
@@ -226,13 +226,13 @@ def send_response(event, context, response):
 def lambda_handler(event, context):
     """Lambda function handler"""
 
-    if event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
+    if event.get('RequestType') in ('Create', 'Update'):
         send_response(event, context, "SUCCESS")
 
-    if event['RequestType'] == 'Delete':
+    if event.get('RequestType') == 'Delete':
         send_response(event, context, "SUCCESS")
         return # skip function execution
-        
+
     tags_tree = defaultdict(list)
     cost_categories_arns = {}
     org_accounts = []


### PR DESCRIPTION
*Description of changes:*

This PR fixes a KeyError when event bridge triggers the Lambda.

```
LAMBDA_WARNING: Unhandled exception. The most likely cause is an issue in the function code. However, in rare cases, a Lambda runtime update can cause unexpected function behavior. For functions using managed runtimes, runtime updates can be triggered by a function change, or can be applied automatically. To determine if the runtime has been updated, check the runtime version in the INIT_START log entry. If this error correlates with a change in the runtime version, you may be able to mitigate this error by temporarily rolling back to the previous runtime version. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html

[ERROR] KeyError: 'RequestType'
Traceback (most recent call last):
  File "/var/task/index.py", line 229, in lambda_handler
    if event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
```

- Tested updating CFN tags, and event bridge trigger and works now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
